### PR TITLE
Allow additional drivers to the geotiff writer

### DIFF
--- a/src/SpeciesDistributionToolkit.jl
+++ b/src/SpeciesDistributionToolkit.jl
@@ -21,6 +21,7 @@ using Reexport
 # Functions for IO
 include("io/geotiff.jl")
 include("io/ascii.jl")
+include("io/read_write.jl")
 
 # Integrate the datasets to the layers
 include("integrations/datasets_layers.jl")

--- a/src/integrations/datasets_layers.jl
+++ b/src/integrations/datasets_layers.jl
@@ -6,7 +6,7 @@ function SimpleSDMLayers.SimpleSDMPredictor(data::R; kwargs...) where {R <: Rast
     filepath, filetype, bandnumber, crs = downloader(data; arguments...)
 
     if isequal(SimpleSDMDatasets._tiff)(filetype)
-        return geotiff(SimpleSDMPredictor, filepath, bandnumber; boundingbox...)
+        return SimpleSDMPredictor(filepath, "tiff"; bandnumber = bandnumber, boundingbox...)
     end
 
     return nothing
@@ -24,7 +24,7 @@ function SimpleSDMLayers.SimpleSDMPredictor(
     filepath, filetype, bandnumber, crs = downloader(data, future; arguments...)
 
     if isequal(SimpleSDMDatasets._tiff)(filetype)
-        return geotiff(SimpleSDMPredictor, filepath, bandnumber; boundingbox...)
+        return SimpleSDMPredictor(filepath, "tiff"; bandnumber = bandnumber, boundingbox...)
     end
 
     return nothing

--- a/src/io/read_write.jl
+++ b/src/io/read_write.jl
@@ -1,0 +1,43 @@
+for layertype in (:SimpleSDMResponse, :SimpleSDMPredictor)
+    eval(
+        quote
+            function SimpleSDMLayers.$layertype(
+                file::String,
+                format = "tiff";
+                bandnumber::Integer = 1,
+                left = nothing,
+                right = nothing,
+                bottom = nothing,
+                top = nothing,
+            )
+                @assert isfile(file)
+                if endswith(file, ".tif") | endswith(file, ".tiff") |
+                   (format in ["tiff", "tif"])
+                    return SpeciesDistributionToolkit._read_geotiff(
+                        file, $layertype; bandnumber = bandnumber, left = left,
+                        right = right, bottom = bottom, top = top,
+                    )
+                end
+            end
+
+            function save(
+                file::String,
+                layers::Vector{$layertype{T}};
+                kwargs...,
+            ) where {T <: Number}
+                if endswith(file, ".tif") | endswith(file, ".tiff")
+                    _write_geotiff(file, layers; kwargs...)
+                    return file
+                end
+            end
+
+            function save(
+                file::String,
+                layer::$layertype{T};
+                kwargs...,
+            ) where {T <: Number}
+                return SpeciesDistributionToolkit.save(file, [layer]; kwargs...)
+            end
+        end,
+    )
+end

--- a/src/io/read_write.jl
+++ b/src/io/read_write.jl
@@ -18,6 +18,7 @@ for layertype in (:SimpleSDMResponse, :SimpleSDMPredictor)
                         right = right, bottom = bottom, top = top,
                     )
                 end
+                @error "Only tiff files are supported at the moment"
             end
 
             function save(
@@ -29,6 +30,7 @@ for layertype in (:SimpleSDMResponse, :SimpleSDMPredictor)
                     _write_geotiff(file, layers; kwargs...)
                     return file
                 end
+                @error "Only tiff files are supported at the moment"
             end
 
             function save(


### PR DESCRIPTION
New syntax to *read* geotiffs:

~~~ julia
path = ".../file.tif"
L = SimpleSDMPredictor(path; bandnumber=2, left=-100., right=10.4, top=0.1, bottom=-12.0)
~~~

New syntax to *write* geotiffs:

~~~ julia
SpeciesDistributionToolkit.save(path, L; driver="COG")
~~~

- Closes #30
- Closes #38
