### PR TITLE
Fix clipping with exact coordinates

### DIFF
--- a/SimpleSDMLayers/src/lib/clip.jl
+++ b/SimpleSDMLayers/src/lib/clip.jl
@@ -11,12 +11,16 @@ function clip(layer::T, p1::Point, p2::Point) where {T <: SimpleSDMLayer}
     pmin = _point_to_cartesian(layer, Point(minimum(lonextr), minimum(latextr)); side=:bottomleft)
     pmax = _point_to_cartesian(layer, Point(maximum(lonextr), maximum(latextr)); side=:topright)
     R = T <: SimpleSDMResponse ? SimpleSDMResponse : SimpleSDMPredictor
+    left = longitudes(layer)[last(pmin.I)]-stride(layer, 1)
+    right = longitudes(layer)[last(pmax.I)]+stride(layer, 1)
+    bottom = latitudes(layer)[first(pmin.I)]-stride(layer, 2)
+    top = latitudes(layer)[first(pmax.I)]+stride(layer, 2)
     return R(
-        layer.grid[pmin:pmax], 
-        longitudes(layer)[last(pmin.I)]-stride(layer, 1),
-        longitudes(layer)[last(pmax.I)]+stride(layer, 1),
-        latitudes(layer)[first(pmin.I)]-stride(layer, 2),
-        latitudes(layer)[first(pmax.I)]+stride(layer, 2)
+        layer.grid[pmin:pmax],
+        left = isapprox(left, round(left)) ? round(left) : left,
+        right = isapprox(right, round(right)) ? round(right) : right,
+        bottom = isapprox(bottom, round(bottom)) ? round(bottom) : bottom,
+        top = isapprox(top, round(top)) ? round(top) : top
     )
 end
 

--- a/SimpleSDMLayers/src/lib/coordinateconversion.jl
+++ b/SimpleSDMLayers/src/lib/coordinateconversion.jl
@@ -20,6 +20,9 @@ function _match_latitude(layer::T, lat::K; lower::Bool=true) where {T <: SimpleS
     relative = (lat - layer.bottom)/(layer.top - layer.bottom)
     fractional = relative * size(layer, 1)+1
     if lat in layer.bottom:2stride(layer,2):layer.top
+        if abs(fractional - round(fractional)) < stride(layer, 2)
+            fractional = round(fractional)
+        end
         f = lower ? floor : ceil
         d = lower ? 1 : 0
         return min(f(Int64, fractional-d), size(layer, 1))
@@ -35,6 +38,9 @@ function _match_longitude(layer::T, lon::K; lower::Bool=true) where {T <: Simple
     relative = (lon - layer.left)/(layer.right - layer.left)
     fractional = relative * size(layer, 2)+1
     if lon in layer.left:2stride(layer,1):layer.right
+        if abs(fractional - round(fractional)) < stride(layer, 1)
+            fractional = round(fractional)
+        end
         f = lower ? floor : ceil
         d = lower ? 1 : 0
         return min(f(Int64, fractional-d), size(layer, 2))


### PR DESCRIPTION
Fixes #143 

This fixes the coordinate clipping issue with the values I tested (as shown in the example below), but I'm not sure if it could cause other issues and I don't think it solves it for all values. 

There are two approximation issues at play here. One is in `_match_latitude` and `_match_longitude` and causes `clip(layer; top=56.0).top` to return the wrong coordinate. My fix there is a bit ugly as I'm not sure what's going in those functions. It is sufficient to fix the issues when clipping with `top` and `left` in my example, but not with `bottom` and `right`.

The 2nd approximation issue occurs in `clip` itself, for instance with `clip(layer; bottom=64.0`. Here the index returned by `_match_latitude` is correct, but subtracting the stride returns 63.9999999999999. I used `isapprox` and `round` to fix it when trying to clip with natural numbers (which should be the most common case to encounter this bug) but I didn't see how to fix it for all coordinates that would be exactly on the boundary without calling `isapprox` on all of them.

The full example:
```julia
julia> using SpeciesDistributionToolkit

julia> spatialrange = (left = -145.0, right = -50.0, bottom = 40.0, top = 89.0);

julia> layer = SimpleSDMPredictor(RasterData(WorldClim2, BioClim); spatialrange...);

julia> clip(layer; top=56.0).top
56.0

julia> clip(layer; top=56.0 - 0.0000001).top
56.0

julia> clip(layer; top=56.0 + 0.0000001).top
56.16666666666667

julia> exact_lats = (spatialrange.bottom+1.0):1.0:(spatialrange.top - 1.0)
41.0:1.0:88.0

julia> exact_lons = (spatialrange.left+1.0):1.0:(spatialrange.right - 1.0)
-144.0:1.0:-51.0

julia> all(isinteger.([clip(layer; top=l).top for l in exact_lats]))
true

julia> all(isinteger.([clip(layer; bottom=l).bottom for l in exact_lats]))
true

julia> all(isinteger.([clip(layer; right=l).right for l in exact_lons]))
true

julia> all(isinteger.([clip(layer; left=l).left for l in exact_lons]))
true
```