### PR TITLE
Test for clipping with natural coordinates

### DIFF
--- a/SimpleSDMLayers/test/operations/clip.jl
+++ b/SimpleSDMLayers/test/operations/clip.jl
@@ -20,4 +20,13 @@ cl2 = clip(S; left=0.2, bottom=0.5)
 @test cl2.right ≈ 1.0
 @test cl2.left ≈ 0.2
 
+M2 = rand(Bool, (1080, 2160))
+S2 = SimpleSDMPredictor(M2, -180.0, 180.0, -90.0, 90.0)
+exact_lats = (S2.bottom+1.0):1.0:(S2.top-1.0)
+exact_lons = (S2.left+1.0):1.0:(S2.right-1.0)
+@test all([isequal(l, clip(S2; top=l).top) for l in exact_lats])
+@test all([isequal(l, clip(S2; bottom=l).bottom) for l in exact_lats])
+@test all([isequal(l, clip(S2; left=l).left) for l in exact_lons])
+@test all([isequal(l, clip(S2; right=l).right) for l in exact_lons])
+
 end


### PR DESCRIPTION
Fixes #149 as the test (and the clipping call) works for exact natural coordinates.

However, we have an example right in the test of a clip with a Float that returns an approximation error:

```
julia> M = rand(Bool, (10, 10));
       S = SimpleSDMPredictor(M, 0.0, 1.0, 0.0, 1.0);
       cl1 = clip(S; left=0.2, right=0.6, bottom=0.5, top=1.0)
SDM predictor → 5×4 grid with 20 Bool-valued cells
  Latitudes     0.5 ⇢ 1.0
  Longitudes    0.2 ⇢ 0.6000000000000001
 ```
 
 I think we should fix `clip` first, then adapt the test accordingly.