### PR TITLE
GBIF throws 404 (not 410) for deleted resources

### DIFF
--- a/GBIF/Project.toml
+++ b/GBIF/Project.toml
@@ -1,7 +1,7 @@
 name = "GBIF"
 uuid = "ee291a33-5a6c-5552-a3c8-0f29a1181037"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/GBIF/src/occurrence.jl
+++ b/GBIF/src/occurrence.jl
@@ -38,12 +38,17 @@ throw an error.
 """
 function occurrence(key::String)::GBIFRecord
     occ_url = gbifurl * "occurrence/" * key
-    occ_key_req = HTTP.get(occ_url)
-    if occ_key_req.status == 200
+    try
+        occ_key_req = HTTP.get(occ_url)
         result = JSON.parse(String(occ_key_req.body))
         return GBIFRecord(result)
+    catch err
+        if err isa HTTP.Exceptions.StatusError
+            throw("Occurrence $(key) (at $(occ_url)) cannot be accessed - error code: $(err.status)")
+        else
+            throw("Occurrence $(key) cannot be accessed")
+        end
     end
-    throw("Occurrence $(key) cannot be accessed")
 end
 
 function occurrence(key::Integer)::GBIFRecord

--- a/GBIF/test/occurrence.jl
+++ b/GBIF/test/occurrence.jl
@@ -3,6 +3,13 @@ module TestOccurrence
 using GBIF
 using Test
 
+# This occurrence exists 
+k = 3986160931
+o = occurrence(k)
+@test typeof(o) == GBIFRecord
+@test o.key == k
+
+# This piece of shit occurrence has been deleted, so this needs some wrapping
 k = 1258202889
 o = occurrence(k)
 @test typeof(o) == GBIFRecord

--- a/GBIF/test/occurrence.jl
+++ b/GBIF/test/occurrence.jl
@@ -9,13 +9,11 @@ o = occurrence(k)
 @test typeof(o) == GBIFRecord
 @test o.key == k
 
-# This piece of shit occurrence has been deleted, so this needs some wrapping
+# This occurrence has been deleted, so this needs some wrapping
 k = 1258202889
-o = occurrence(k)
-@test typeof(o) == GBIFRecord
-@test o.key == k
+@test_throws "cannot be accessed - error code" occurrence(k)
 
-# Piece of shit uncorrectly formatted occurence
+# This occurence is incorrectly formatted for some reason
 k = 1039645472
 o = occurrence(k)
 @test typeof(o) == GBIFRecord


### PR DESCRIPTION
- [x] Update the tests with a failing occurrence
- [x] Add a way to handle 404 when querying deleted occurrences