### PR TITLE
Phylopic pre-compilation fix

### DIFF
--- a/Phylopic/Project.toml
+++ b/Phylopic/Project.toml
@@ -1,7 +1,7 @@
 name = "Phylopic"
 uuid = "c889285c-44aa-4473-b1e1-56f5d4e3ccf5"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>"]
-version = "0.0.3"
+version = "0.0.4"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/Phylopic/src/Phylopic.jl
+++ b/Phylopic/src/Phylopic.jl
@@ -15,9 +15,9 @@ include("ping.jl")
 function __init__()
     # We do a first ping to fail ASAP if the API is not responsive
     @assert isnothing(Phylopic.ping())
-    # We put the buildnumber in a const to avoid calling it multiple times -- this is a required
-    # parameter for a large number of queries (most of the queries, in fact)
-    return Phylopic.buildnumber = Phylopic.build()
+    # We put the buildnumber in a package-level variable
+    Phylopic.buildnumber = Phylopic.build()
+    return nothing
 end
 
 # The autocomplete endpoint is meant to give an overview of possible names starting from

--- a/Phylopic/src/Phylopic.jl
+++ b/Phylopic/src/Phylopic.jl
@@ -12,12 +12,13 @@ const api = "https://api.phylopic.org/"
 # of the current build by default, as it is required for most operations.
 include("ping.jl")
 
-# We do a first ping to fail ASAP if the API is not responsive
-@assert isnothing(Phylopic.ping())
-
-# We put the buildnumber in a const to avoid calling it multiple times -- this is a required
-# parameter for a large number of queries (most of the queries, in fact)
-buildnumber = Phylopic.build()
+function __init__()
+    # We do a first ping to fail ASAP if the API is not responsive
+    @assert isnothing(Phylopic.ping())
+    # We put the buildnumber in a const to avoid calling it multiple times -- this is a required
+    # parameter for a large number of queries (most of the queries, in fact)
+    return Phylopic.buildnumber = Phylopic.build()
+end
 
 # The autocomplete endpoint is meant to give an overview of possible names starting from
 # a stem - this is not necessarilly going to give all of the names, and I am not sure why
@@ -27,4 +28,4 @@ include("imagesof.jl")
 include("images.jl")
 include("attribution.jl")
 
-end # module hylopic
+end # module Phylopic

--- a/Phylopic/src/images.jl
+++ b/Phylopic/src/images.jl
@@ -92,7 +92,11 @@ Returns the URL to an image in raster format when no resolution is specified. In
 function raster(uuid::UUIDs.UUID)
     lnk = Phylopic.images_links(uuid)
     if ~isnothing(lnk)
-        return first(lnk)["href"]
+        if haskey(lnk, "rasterFiles")
+            return first(lnk["rasterFiles"])["href"]
+        else
+            return nothing
+        end
     end
     return nothing
 end


### PR DESCRIPTION
Phylopic precompilation was not terminating with Julia 1.10 -- this is now fixed, specifically by moving the code that was floating in the package into the `__init__` function.

Closes #223
